### PR TITLE
Update req.body parse method 

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
-const app = require('express')();
+const express = require('express');
+const app = express();
 const mongoose = require('mongoose');
 const cors = require('cors');
-const bodyParser = require('body-parser');
 const session = require('express-session');
 const MongoDBStore = require('connect-mongodb-session')(session);
 const passport = require('passport');
@@ -17,8 +17,8 @@ const store = new MongoDBStore({
 });
 
 app.use(cors());
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 
 app.use(cookieParser(process.env.SECRET));
 app.use(

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
-    "body-parser": "^1.18.3",
     "connect-mongodb-session": "^2.2.0",
     "cookie-parser": "^1.4.4",
     "cors": "^2.8.5",


### PR DESCRIPTION
As of Express v.14.16.0 bodyParser method was bundled again with express as a build in method.
For reference: 
https://github.com/expressjs/express/releases/tag/4.16.0